### PR TITLE
Fix raw input with nested name

### DIFF
--- a/views/assets/css/phone_number_field.css
+++ b/views/assets/css/phone_number_field.css
@@ -22,3 +22,8 @@
 .iti--inline-dropdown .iti__dropdown-content {
   margin-top: 0;
 }
+
+.iti--inline-dropdown--flipped {
+  display: flex;
+  flex-direction: column-reverse;
+}

--- a/views/assets/js/phone_number_field.js
+++ b/views/assets/js/phone_number_field.js
@@ -67,9 +67,10 @@ class PhoneNumberField {
             this.intlTelInput.dropdown.style.top = `${rect.bottom - 5}px`
         })
 
-        // PhoneNumberField submits a different value than that contained in the named input, so
-        // rename the input field to allow the plugin's value to replace the original in form data:
-        this.input.name = `${this.input.name}_raw`
+        // PhoneNumberField wraps a text field, which also submits params. Since the plugin is
+        // responsible for submitting a value, ensure the enclosed text field doesn't submit
+        // anything:
+        this.input.vComponent.prepareSubmit = () => {}
 
         if (this.input.value) {
             // input may be coming in with or without leading `+`, so normalize and trim:

--- a/views/assets/js/phone_number_field.js
+++ b/views/assets/js/phone_number_field.js
@@ -40,21 +40,10 @@ class PhoneNumberField {
 
         // need to adjust the MDC floating label's left offset to account for the country code
         // picker:
-        this.input.addEventListener("countrychange", (event) => {
-            this.updateDropdown()
-        })
-
-        this.input.addEventListener("input", (event) => {
-            this.updateDropdown()
-        })
-
-        this.input.addEventListener("blur", (event) => {
-            this.updateDropdown()
-        })
-
-        this.input.addEventListener("focus", (event) => {
-            this.updateDropdown()
-        })
+        this.input.addEventListener("countrychange", () => this.updateDropdown())
+        this.input.addEventListener("input", () => this.updateDropdown())
+        this.input.addEventListener("blur", () => this.updateDropdown())
+        this.input.addEventListener("focus", () => this.updateDropdown())
 
         this.input.addEventListener("open:countrydropdown", (event) => {
             if (this.intlTelInput.useFullscreenPopup) {
@@ -63,8 +52,20 @@ class PhoneNumberField {
 
             // IntlTelInput seems to not play nice with COPRL's layout when the body is scrolled
             // beyond the top of the viewport, so manually adjust the dropdown container:
-            const rect = this.element.getBoundingClientRect()
-            this.intlTelInput.dropdown.style.top = `${rect.bottom - 5}px`
+            const elementRect = this.element.getBoundingClientRect()
+            const dropdownRect = this.intlTelInput.dropdown.querySelector(".iti__dropdown-content").getBoundingClientRect()
+            const scrollBottom = document.scrollingElement.scrollTop + window.innerHeight
+
+            if (dropdownRect.bottom > scrollBottom) {
+                this.intlTelInput.dropdown.style.top = `${elementRect.top + 5}px`
+                this.intlTelInput.dropdown.classList.add("iti--inline-dropdown--flipped")
+            } else {
+                this.intlTelInput.dropdown.style.top = `${elementRect.bottom - 5}px`
+            }
+        })
+
+        this.input.addEventListener("close:countrydropdown", (event) => {
+            this.intlTelInput.dropdown.classList.remove("iti--inline-dropdown--flipped")
         })
 
         // PhoneNumberField wraps a text field, which also submits params. Since the plugin is

--- a/views/assets/js/phone_number_field.js
+++ b/views/assets/js/phone_number_field.js
@@ -35,7 +35,8 @@ class PhoneNumberField {
             showFlags: false,
             showSelectedDialCode: true,
             initialCountry: this.element.dataset.defaultCountry,
-            defaultToFirstCountry: Boolean(this.element.dataset.defaultCountry)
+            defaultToFirstCountry: Boolean(this.element.dataset.defaultCountry),
+            useFullscreenPopup: this.isMobile
         })
 
         // need to adjust the MDC floating label's left offset to account for the country code
@@ -46,7 +47,7 @@ class PhoneNumberField {
         this.input.addEventListener("focus", () => this.updateDropdown())
 
         this.input.addEventListener("open:countrydropdown", (event) => {
-            if (this.intlTelInput.useFullscreenPopup) {
+            if (this.isMobile) {
                 return
             }
 
@@ -165,5 +166,11 @@ class PhoneNumberField {
     /** @private */
     get locale() {
         return this.element.dataset.locale || (new Intl.NumberFormat()).resolvedOptions().locale
+    }
+
+    /** @private */
+    get isMobile() {
+        // from IntlTelInput
+        return window.innerWidth <= 500
     }
 }


### PR DESCRIPTION
* Remove raw text field value from submitted data
* Flip dropdown when near the bottom of the page
* Fix mobile/full-screen check
  * Since the plugin pulls in a minified distribution of IntlTelInput, it can't reference any configuration members, as they've been mangled.