### PR TITLE
Output the JS raw so things don't get escaped

### DIFF
--- a/views/components/application/_phone_number_field_header.erb
+++ b/views/components/application/_phone_number_field_header.erb
@@ -1,8 +1,8 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/intl-tel-input@19.5.5/build/css/intlTelInput.css">
 <style>
-  <%== File.read(File.expand_path('../../assets/css/phone_number_field.css', __dir__)  ) %>
+  <%= html_safe File.read(File.expand_path('../../assets/css/phone_number_field.css', __dir__)) %>
 </style>
 <script src="https://cdn.jsdelivr.net/npm/intl-tel-input@19.5.5/build/js/intlTelInput.min.js"></script>
 <script>
-  <%== File.read(File.expand_path('../../assets/js/phone_number_field.js', __dir__)  ) %>
+  <%= html_safe File.read(File.expand_path('../../assets/js/phone_number_field.js', __dir__)) %>
 </script>

--- a/views/components/application/_phone_number_field_header.erb
+++ b/views/components/application/_phone_number_field_header.erb
@@ -1,8 +1,8 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/intl-tel-input@19.5.5/build/css/intlTelInput.css">
 <style>
-  <%= File.read(File.expand_path('../../assets/css/phone_number_field.css', __dir__)  ) %>
+  <%== File.read(File.expand_path('../../assets/css/phone_number_field.css', __dir__)  ) %>
 </style>
 <script src="https://cdn.jsdelivr.net/npm/intl-tel-input@19.5.5/build/js/intlTelInput.min.js"></script>
 <script>
-  <%= File.read(File.expand_path('../../assets/js/phone_number_field.js', __dir__)  ) %>
+  <%== File.read(File.expand_path('../../assets/js/phone_number_field.js', __dir__)  ) %>
 </script>


### PR DESCRIPTION
I wonder if this should be done some other way? I don't believe the `<%==` sigil is Sinatra compatible.