### PR TITLE
Submit extension with number when applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ a country code directly into the text field. Input is formatted as it is typed a
 format for the current country code.
 
 The plugin submits the field's value normalized and formatted as an international phone number in
-standard [E.164](https://en.wikipedia.org/wiki/E.164) format.
+standard [E.164](https://en.wikipedia.org/wiki/E.164) format, with extension when applicable.
 
 ## Configuration
 

--- a/views/assets/js/phone_number_field.js
+++ b/views/assets/js/phone_number_field.js
@@ -118,7 +118,14 @@ class PhoneNumberField {
     }
 
     prepareSubmit(params) {
-        params.push([this.originalName, this.intlTelInput.getNumber()])
+        let number = this.intlTelInput.getNumber(0)
+        const extension = this.intlTelInput.getExtension()
+
+        if (extension) {
+            number = `${number} x${extension}`
+        }
+
+        params.push([this.originalName, number])
     }
 
     reset() {


### PR DESCRIPTION
The plugin accepts and validates phone numbers with an extension, but silently discards the extension portion of the number when submitting a value. This change attaches the extension to the end of the string submitted by the plugin, if applicable.